### PR TITLE
[github] use id/pwd

### DIFF
--- a/.github/workflows/pub_pypi.yml
+++ b/.github/workflows/pub_pypi.yml
@@ -30,3 +30,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+          user: __token__
+          password: ${{ secrets.PYPI_PUB_TOKEN }}


### PR DESCRIPTION
use id/pwd for the first publication.