### PR TITLE
[github] Fix Action warnings

### DIFF
--- a/.github/workflows/pub_pypi.yml
+++ b/.github/workflows/pub_pypi.yml
@@ -13,12 +13,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: Install build dependencies
         run: python -m pip install -U setuptools wheel build


### PR DESCRIPTION
This will fix github action warnings with node version.
And to use python3.10 not python3.8